### PR TITLE
Export schema

### DIFF
--- a/src/BusinessApi.ts
+++ b/src/BusinessApi.ts
@@ -1,5 +1,8 @@
+import { Schema } from "./Schema";
 export interface BusinessApi {
   listen(): { close(): void };
+
+  getSchema(): Schema;
 
   call(urlEnv: string): {
     requestSchema<REQUEST>(requestDefinition: string): {

--- a/src/BusinessApiAbstract.ts
+++ b/src/BusinessApiAbstract.ts
@@ -24,6 +24,10 @@ export abstract class BusinessApiAbstract implements BusinessApi {
     body?: any;
   }): Promise<{ status: number; data: any }>;
 
+  getSchema() {
+    return this.schema;
+  }
+
   call(urlEnv: string) {
     return {
       responseSchema: <RESPONSE>(responseDefinition: string) => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./BusinessApi";
 export * from "./BusinessApiHTTP";
 export * from "./BusinessApiTest";
+export * from "./Schema";


### PR DESCRIPTION
It is useful to use BusinessApi as a global toolkit for managing business logic api service. Schema validation is among the essential tasks so it should be available at the BusinessApi interface